### PR TITLE
Use latest travis-config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,8 +134,8 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.7)
     tins (1.15.0)
-    travis-config (1.1.2)
-      hashr (~> 2.0.0)
+    travis-config (1.1.3)
+      hashr (~> 2.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     yubikey (1.4.1)
@@ -165,4 +165,4 @@ DEPENDENCIES
   travis-yml!
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -16,7 +16,7 @@ module Checker
       define admins: []
     end
 
-    config = Travis::Config.load(:files, :keychain, :heroku)
+    config = Travis::Config.load
 
     # authenticate users
     enable :sessions


### PR DESCRIPTION
This change uses the latest travis-config which has had this bug fixed: https://github.com/travis-pro/team-teal/issues/2093

The workaround to avoid the error has also been removed.

The branch has been deployed and tested on org-staging and all is working as expected.