### PR TITLE
Fix Sentry reporting, bump travis-yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'slim'
 gem 'rack-ssl'
 gem 'librato-metrics'
 
-gem 'travis-yml', git: 'https://github.com/travis-ci/travis-yml', ref: '3e6aa8833'
+gem 'travis-yml', git: 'https://github.com/travis-ci/travis-yml'
 gem 'travis-config'
 gem 'travis-sso', git: 'https://github.com/travis-ci/travis-sso'
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'slim'
 gem 'rack-ssl'
 gem 'librato-metrics'
 
-gem 'travis-yml', git: 'https://github.com/travis-ci/travis-yml'
+gem 'travis-yml', git: 'https://github.com/travis-ci/travis-yml', ref: '3e6aa8833'
 gem 'travis-config'
 gem 'travis-sso', git: 'https://github.com/travis-ci/travis-sso'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-yml
-  revision: 3e6aa8833d085c8dce1a2714ff1f1f4ed5827538
-  ref: 3e6aa8833
+  revision: 6faf448424b1cc4d622780cba8f823a09b692c94
   specs:
     travis-yml (0.0.1)
       amatch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-yml
-  revision: 6faf448424b1cc4d622780cba8f823a09b692c94
+  revision: 3e6aa8833d085c8dce1a2714ff1f1f4ed5827538
+  ref: 3e6aa8833
   specs:
     travis-yml (0.0.1)
       amatch

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-yml
-  revision: 3e6aa8833d085c8dce1a2714ff1f1f4ed5827538
+  revision: 6faf448424b1cc4d622780cba8f823a09b692c94
   specs:
     travis-yml (0.0.1)
       amatch

--- a/config.ru
+++ b/config.ru
@@ -2,10 +2,6 @@ require_relative './lib/checker'
 require 'rack/ssl'
 require 'raven'
 
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
-end
-
 use Raven::Rack
 use Rack::Static, urls: ['/js', '/css', '/favicon.ico', '/img'], root: 'public'
 use Rack::SSL if Sinatra::Application.production?

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,11 @@
 require_relative './lib/checker'
 require 'rack/ssl'
 require 'raven'
+
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_URL']
+end
+
 use Raven::Rack
 use Rack::Static, urls: ['/js', '/css', '/favicon.ico', '/img'], root: 'public'
 use Rack::SSL if Sinatra::Application.production?

--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,7 @@ require 'rack/ssl'
 require 'raven'
 
 Raven.configure do |config|
-  config.dsn = ENV['SENTRY_URL']
+  config.dsn = ENV['SENTRY_DSN']
 end
 
 use Raven::Rack

--- a/config/sidekiq.rb
+++ b/config/sidekiq.rb
@@ -34,9 +34,12 @@ end
 
 LibratoClient.authenticate
 
-require 'raven'
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
+if ENV['ENV'] == 'production'
+  require 'raven'
+  Raven.configure do |config|
+    return unless ENV['SENTRY_DSN']
+    config.dsn = ENV['SENTRY_DSN']
+  end
 end
 
 require 'build_worker'

--- a/config/sidekiq.rb
+++ b/config/sidekiq.rb
@@ -34,6 +34,12 @@ end
 
 LibratoClient.authenticate
 
+require 'raven'
+Raven.configure do |config|
+  config.dsn = ENV['SENTRY_DSN']
+end
+use Raven::Rack
+
 require 'build_worker'
 require 'config_worker'
 require 'librato_worker'

--- a/config/sidekiq.rb
+++ b/config/sidekiq.rb
@@ -38,7 +38,6 @@ require 'raven'
 Raven.configure do |config|
   config.dsn = ENV['SENTRY_DSN']
 end
-use Raven::Rack
 
 require 'build_worker'
 require 'config_worker'


### PR DESCRIPTION
This ensures errors raised in the sidekiq processes report to Sentry.
It bumps travis-yml to fix the ArgumentError that was being raised: https://sentry.io/travis-ci/travis-yml-checker/issues/320844973/