### PR TITLE
Add a summary of erroring repositories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     temple (0.8.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.7)
+    tilt (2.0.8)
     tins (1.15.0)
     travis-config (1.1.3)
       hashr (~> 2.0)

--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -30,6 +30,13 @@ module Checker
       .to_a
       .group_by{|h| h["level"]}.each{|_, v| v.each {|h| h.delete("level")}}
 
+      @erroring_repos = Result.connection.exec_query("SELECT COUNT (results.id), repo_id
+                                                      FROM results
+                                                      INNER JOIN messages ON results.id = messages.result_id
+                                                      WHERE messages.level = 'error'
+                                                      GROUP BY repo_id
+                                                      ORDER BY COUNT (results.id) DESC;").to_a
+
       slim :index
     end
 

--- a/lib/views/index.slim
+++ b/lib/views/index.slim
@@ -9,16 +9,29 @@ body
         td class="pv2 ph3 tc" = @results_count
         td class="pv2 ph3 tc" = @messages_count
 
-h3 Messages Summary
-  
-- @messages.each do |level, msgs|
-  table class="fl mr4 collapse ba pv3 ph3"
-    thead
-      tr class="ttu bg-black-05 level-#{level}"
-        th class="pv2 ph3" = level
-        th class="pv2 ph3" = msgs.map {|m| m["count"]}.reduce(0, :+)
-    tbody
-    - msgs.each do |msg|
-      tr
-        td class="pv2 ph3 tc" = msg["code"]
-        td class="pv2 ph3 tc" = msg["count"]
+  h3 Messages Summary
+    
+  - @messages.each do |level, msgs|
+    table class="fl mr4 collapse ba pv3 ph3"
+      thead
+        tr class="ttu bg-black-05 level-#{level}"
+          th class="pv2 ph3" = level
+          th class="pv2 ph3" = msgs.map {|m| m["count"]}.reduce(0, :+)
+      tbody
+      - msgs.each do |msg|
+        tr
+          td class="pv2 ph3 tc" = msg["code"]
+          td class="pv2 ph3 tc" = msg["count"]
+
+  h3 Erroring Repos Summary
+    
+    table class="collapse ba pv3 ph3"
+      thead
+        tr class="striped--light-gray ttu"
+          th class="pv2 ph3" repo
+          th class="pv2 ph3" errors
+      - @erroring_repos.each do |repo|
+      tbody
+        tr
+          td class="pv2 ph3 tc" = repo["repo_id"]
+          td class="pv2 ph3 tc" = repo["count"]

--- a/lib/views/index.slim
+++ b/lib/views/index.slim
@@ -1,37 +1,36 @@
-body
+table class="collapse ba pv3 ph3"
+  thead
+    tr class="striped--light-gray ttu"
+      th class="pv2 ph3" results
+      th class="pv2 ph3" messages
+  tbody
+    tr
+      td class="pv2 ph3 tc" = @results_count
+      td class="pv2 ph3 tc" = @messages_count
+
+h3 Messages Summary
+- @messages.each do |level, msgs|
+  table class="fl mr4 collapse ba pv3 ph3"
+    thead
+      tr class="ttu bg-black-05 level-#{level}"
+        th class="pv2 ph3" = level
+        th class="pv2 ph3" = msgs.map {|m| m["count"]}.reduce(0, :+)
+    tbody
+    - msgs.each do |msg|
+      tr
+        td class="pv2 ph3 tc" = msg["code"]
+        td class="pv2 ph3 tc" = msg["count"]
+
+h3 
+  | Erroring Repos Summary
+  
   table class="collapse ba pv3 ph3"
     thead
       tr class="striped--light-gray ttu"
-        th class="pv2 ph3" results
-        th class="pv2 ph3" messages
+        th class="pv2 ph3" repo
+        th class="pv2 ph3" errors
     tbody
+    - @erroring_repos.each do |repo|
       tr
-        td class="pv2 ph3 tc" = @results_count
-        td class="pv2 ph3 tc" = @messages_count
-
-  h3 Messages Summary
-    
-  - @messages.each do |level, msgs|
-    table class="fl mr4 collapse ba pv3 ph3"
-      thead
-        tr class="ttu bg-black-05 level-#{level}"
-          th class="pv2 ph3" = level
-          th class="pv2 ph3" = msgs.map {|m| m["count"]}.reduce(0, :+)
-      tbody
-      - msgs.each do |msg|
-        tr
-          td class="pv2 ph3 tc" = msg["code"]
-          td class="pv2 ph3 tc" = msg["count"]
-
-  h3 Erroring Repos Summary
-    
-    table class="collapse ba pv3 ph3"
-      thead
-        tr class="striped--light-gray ttu"
-          th class="pv2 ph3" repo
-          th class="pv2 ph3" errors
-      - @erroring_repos.each do |repo|
-      tbody
-        tr
-          td class="pv2 ph3 tc" = repo["repo_id"]
-          td class="pv2 ph3 tc" = repo["count"]
+        td class="pv2 ph3 tc" = repo["repo_id"]
+        td class="pv2 ph3 tc" = repo["count"]

--- a/lib/views/index.slim
+++ b/lib/views/index.slim
@@ -7,7 +7,7 @@ table class="collapse ba pv3 ph3"
     tr
       td class="pv2 ph3 tc" = @results_count
       td class="pv2 ph3 tc" = @messages_count
-
+br
 h3 Messages Summary
 - @messages.each do |level, msgs|
   table class="fl mr4 collapse ba pv3 ph3"
@@ -21,16 +21,18 @@ h3 Messages Summary
         td class="pv2 ph3 tc" = msg["code"]
         td class="pv2 ph3 tc" = msg["count"]
 
-h3 
-  | Erroring Repos Summary
-  
-  table class="collapse ba pv3 ph3"
-    thead
-      tr class="striped--light-gray ttu"
-        th class="pv2 ph3" repo
-        th class="pv2 ph3" errors
-    tbody
-    - @erroring_repos.each do |repo|
-      tr
-        td class="pv2 ph3 tc" = repo["repo_id"]
-        td class="pv2 ph3 tc" = repo["count"]
+.cf
+br
+h3 Erroring Repos Summary
+table class="collapse ba pv3 ph3"
+  thead
+    tr class="striped--light-gray ttu"
+      th class="pv2 ph3" repo
+      th class="pv2 ph3" errors
+      th class="pv2 ph3" last build
+  tbody
+  - @erroring_repos.each do |repo|
+    tr
+      td class="pv2 ph3 tc" <a href="repo/#{repo["repo_id"]}" class="link dim black"> #{repo["repo_id"]}</a>
+      td class="pv2 ph3 tc" = repo["count"]
+      td class="pv2 ph3 tc" = repo["max"][0...-15]

--- a/lib/views/repo.slim
+++ b/lib/views/repo.slim
@@ -1,0 +1,32 @@
+h2 Repository
+- puts ENV['RACK_ENV']
+p
+  - if ENV['RACK_ENV'] == 'staging' 
+    - admin = 'admin-staging'
+  - else
+    - admin = 'admin'
+
+  | Visit repo in <a href="https://#{admin}.travis-ci.org/repository/#{params[:id]}" class="link underline dim black"> admin</a>
+
+h3 Messages
+br
+- if @messages.length > 0
+  table class="collapse ba pv3 ph3 repo_table"
+    thead
+      tr class="striped--light-gray ttu"
+        th class="pv2 ph3" result
+        th class="pv2 ph3" level
+        th class="pv2 ph3" key
+        th class="pv2 ph3" code
+        th class="pv2 ph3" message
+        th class="pv2 ph3" created
+    tbody
+      - @messages.each do |message|
+        tr
+          td class="pv2 ph3" <a href="../result/#{message.result_id}" class="link dim black"> #{message.result_id}</a>
+          td class="pv2 ph3 level-#{message.level}" = message.level
+          td class="pv2 ph3" = message.key
+          td class="pv2 ph3" = message.code
+          td class="pv2 ph3" = Travis::Yaml.msg([message.level, message.key, message.code.to_sym, message.args.symbolize_keys])
+          td class="pv2 ph3" = message.created_at
+br

--- a/lib/views/result.slim
+++ b/lib/views/result.slim
@@ -1,44 +1,43 @@
-body
-  h1 Result
+h1 Result
+table class="collapse ba pv3 ph3"
+  thead
+    tr class="striped--light-gray ttu"
+      th class="pv2 ph3" id
+      th class="pv2 ph3" build id
+      th class="pv2 ph3" repo id
+      th class="pv2 ph3" owner type
+      th class="pv2 ph3" owner id
+      th class="pv2 ph3" request id
+      th class="pv2 ph3" parse time
+
+  tbody
+    tr
+      td class="pv2 ph3 tc" = @result.id
+      td class="pv2 ph3 tc" = @result.build_id
+      td class="pv2 ph3 tc" = @result.repo_id
+      td class="pv2 ph3 tc" = @result.owner_type
+      td class="pv2 ph3 tc" = @result.owner_id
+      td class="pv2 ph3 tc" = @result.request_id
+      td class="pv2 ph3 tc" = "%f" % @result.parse_time if @result.parse_time
+br
+- if @messages.length > 0
   table class="collapse ba pv3 ph3"
     thead
       tr class="striped--light-gray ttu"
-        th class="pv2 ph3" id
-        th class="pv2 ph3" build id
-        th class="pv2 ph3" repo id
-        th class="pv2 ph3" owner type
-        th class="pv2 ph3" owner id
-        th class="pv2 ph3" request id
-        th class="pv2 ph3" parse time
-
+        th class="pv2 ph3" level
+        th class="pv2 ph3" key
+        th class="pv2 ph3" code
+        th class="pv2 ph3" message
     tbody
-      tr
-        td class="pv2 ph3 tc" = @result.id
-        td class="pv2 ph3 tc" = @result.build_id
-        td class="pv2 ph3 tc" = @result.repo_id
-        td class="pv2 ph3 tc" = @result.owner_type
-        td class="pv2 ph3 tc" = @result.owner_id
-        td class="pv2 ph3 tc" = @result.request_id
-        td class="pv2 ph3 tc" = "%f" % @result.parse_time if @result.parse_time
-  br
-  - if @messages.length > 0
-    table class="collapse ba pv3 ph3"
-      thead
-        tr class="striped--light-gray ttu"
-          th class="pv2 ph3" level
-          th class="pv2 ph3" key
-          th class="pv2 ph3" code
-          th class="pv2 ph3" message
-      tbody
-        - @messages.each do |message|
-          tr
-            td class="pv2 ph3 level-#{message.level}" = message.level
-            td class="pv2 ph3" = message.key
-            td class="pv2 ph3" = message.code
-            td class="pv2 ph3" = Travis::Yaml.msg([message.level, message.key, message.code.to_sym, message.args.symbolize_keys])
-  br
+      - @messages.each do |message|
+        tr
+          td class="pv2 ph3 level-#{message.level}" = message.level
+          td class="pv2 ph3" = message.key
+          td class="pv2 ph3" = message.code
+          td class="pv2 ph3" = Travis::Yaml.msg([message.level, message.key, message.code.to_sym, message.args.symbolize_keys])
+br
 
-  h2 Original Config
-  pre = @result.original_config
-  h2 Parsed Config
-  pre = JSON.pretty_generate(@result.parsed_config)
+h2 Original Config
+pre = @result.original_config
+h2 Parsed Config
+pre = JSON.pretty_generate(@result.parsed_config)

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,14 +40,6 @@ body {
   background-color: #f1f1f1;
   height: 55px; }
 
-.inner {
-  max-width: 1200px;
-  margin: auto;
-  padding: 0 0.9375rem; }
-  @media (min-width: 64.063em) {
-    .inner {
-      padding: 0; } }
-
 .main {
   padding: 30px 0;
 }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -44,3 +44,7 @@
 .main {
   padding: 30px 0;
 }
+
+.repo_table td:nth-of-type(5){
+  width: 1%
+}


### PR DESCRIPTION
This add a summary of erroring repos to the index page, with links to a new `/repo/:id` page that lists all the messages generated by that repo, and a link to the yml-checker `/result/:id` page

Partially addresses this issue: https://github.com/travis-pro/team-teal/issues/2171