### PR TITLE
Add summary of most common Args

### DIFF
--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -57,6 +57,12 @@ module Checker
       slim :repo
     end
 
+    get '/args/:code' do
+      @messages = Message.where(code: params[:code])
+      @args = @messages.group_by{|a| a.args }.sort_by{|arg, group| group.count }.reverse
+      slim :args
+    end
+
     #only works when ENV=production
     error ActiveRecord::RecordNotFound do
       slim :oops

--- a/lib/views/args.slim
+++ b/lib/views/args.slim
@@ -1,0 +1,25 @@
+h2 Args 
+
+table class="collapse ba pv3 ph3"
+  thead
+    tr class="striped--light-gray ttu"
+      th class="pv2 ph3" level
+      th class="pv2 ph3" code
+  tbody
+    tr
+      td class="pv2 ph3 level-#{@args.first[1][0][:level]}" = @args.first[1][0][:level]
+      td class="pv2 ph3" = @args.first[1][0][:code]
+br
+- if @args.length > 0
+  table class="collapse ba pv3 ph3"
+    thead
+      tr class="striped--light-gray ttu"
+        th class="pv2 ph3" count
+        th class="pv2 ph3" key
+        th class="pv2 ph3" args
+    tbody
+      - @args.each do |arg, group|
+        tr
+          td class="pv2 ph3" = group.count
+          td class="pv2 ph3" = group.first[:key]
+          td class="pv2 ph3" = arg

--- a/lib/views/index.slim
+++ b/lib/views/index.slim
@@ -18,9 +18,8 @@ h3 Messages Summary
     tbody
     - msgs.each do |msg|
       tr
-        td class="pv2 ph3 tc" = msg["code"]
+        td class="pv2 ph3 tc" <a href="args/#{msg["code"]}" class="link dim black"> #{msg["code"]}</a>
         td class="pv2 ph3 tc" = msg["count"]
-
 .cf
 br
 h3 Erroring Repos Summary


### PR DESCRIPTION
This PR add an `args/:code` route which displays a grouping by count of the args common to the `params[:code]`. 

The page can be accessed from the Messages Summary table on the index page.

This completes work on https://github.com/travis-pro/team-teal/issues/2171