### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+ENV.delete('DATABASE_URL')
 ENV['ENV'] = ENV['RAILS_ENV'] = ENV['RACK_ENV'] = 'test'
 
 require_relative '../config/sidekiq'


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database